### PR TITLE
Add OpenEdge ABL Class Browser and PASOE Manager VSCode extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ If you think open source is a good idea, don't hesitate to recommend it to Progr
 - [usagi-coffee/vscode-openedge-abl](https://github.com/usagi-coffee/vscode-openedge-abl) - VSCode extension for OpenEdge ABL language support.
 - [chriscamicas/vscode-abl](https://github.com/chriscamicas/vscode-abl) - Openedge plugin with Compiler, Debugger,... **[😴 inactive]**
 - [ezequielgandolfi/openedge-zext](https://github.com/ezequielgandolfi/openedge-zext) - Another Openedge plugin **[😴 inactive]**
+- [consultingwerk/OpenEdge ABL Class Browser](https://marketplace.visualstudio.com/itemsitemName=ConsultingwerkApplicationModernizationSolutionsLtd.classbrowser) - VSCode extension to browse and explore OpenEdge ABL classes and their structure.
+- [consultingwerk/PASOE Manager Extension](https://marketplace.visualstudio.com/itemsitemName=ConsultingwerkApplicationModernizationSolutionsLtd.oemanager) - VSCode extension to manage PASOE instances and sessions in Visual Studio Code.
 
 ### dev containers
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you think open source is a good idea, don't hesitate to recommend it to Progr
 - [chriscamicas/vscode-abl](https://github.com/chriscamicas/vscode-abl) - Openedge plugin with Compiler, Debugger,... **[😴 inactive]**
 - [ezequielgandolfi/openedge-zext](https://github.com/ezequielgandolfi/openedge-zext) - Another Openedge plugin **[😴 inactive]**
 - [consultingwerk/OpenEdge ABL Class Browser](https://marketplace.visualstudio.com/itemsitemName=ConsultingwerkApplicationModernizationSolutionsLtd.classbrowser) - VSCode extension to browse and explore OpenEdge ABL classes and their structure.
-- [consultingwerk/PASOE Manager Extension](https://marketplace.visualstudio.com/itemsitemName=ConsultingwerkApplicationModernizationSolutionsLtd.oemanager) - VSCode extension to manage PASOE instances and sessions in Visual Studio Code.
+- [consultingwerk/PASOE Manager Extension](https://marketplace.visualstudio.com/itemsitemName=ConsultingwerkApplicationModernizationSolutionsLtd.oemanager) - VSCode extension to manage Progress Application Server for OpenEdge (PASOE) instances and sessions in Visual Studio Code.
 
 ### dev containers
 


### PR DESCRIPTION
I would like to add two VSCode extensions developed by Consultingwerk for OpenEdge ABL:

1. ABL Class Browser - Allows developers to browse and explore OpenEdge ABL classes and their structure.
2. PASOE Manager Extension - Provides management capabilities for PASOE instances and sessions directly within Visual Studio Code.

Both extensions are publicly available via the Visual Studio Code Marketplace and https://open-vsx.org/ and are actively used in development workflows.

- ABL Class Browser (https://marketplace.visualstudio.com/itemsitemName=ConsultingwerkApplicationModernizationSolutionsLtd.classbrowser) 
- PASOE Manager Extension (https://marketplace.visualstudio.com/itemsitemName=ConsultingwerkApplicationModernizationSolutionsLtd.oemanager)